### PR TITLE
strip controller- prefix from tag for semantic versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
   }
   environment {
     DIRECTORY = "src/github.com/infobloxopen/ingress-nginx"
-    GIT_VERSION = sh(script: "cd ${DIRECTORY} && git describe --always --long --tags",
+    GIT_VERSION = sh(script: "cd ${DIRECTORY} && git describe --always --long --tags --match 'controller-*' | sed s/controller-//",
                        returnStdout: true).trim()
     TAG = "${env.GIT_VERSION}-j${env.BUILD_NUMBER}-nginx"
     REGISTRY = 'infoblox'


### PR DESCRIPTION
Fixes errors like this:
```
Error: template: ib-nginx-ingress/charts/ingress-nginx/templates/controller-deployment.yaml:2:4: executing "ib-nginx-ingress/charts/ingress-nginx/templates/controller-deployment.yaml" at <include "isControllerTagValid" .>: error calling include: template: ib-nginx-ingress/charts/ingress-nginx/templates/_helpers.tpl:121:12: executing "isControllerTagValid" at <semverCompare ">=0.27.0-0" .Values.controller.image.tag>: error calling semverCompare: Invalid Semantic Version
```
Which happen when images are tagged like `infoblox/nginx-fips:controller-v0.45.0-7-g555f2f8-j5-ingress`